### PR TITLE
ensure requests are properly signed

### DIFF
--- a/src/vinyldns.js
+++ b/src/vinyldns.js
@@ -66,12 +66,13 @@ class VinylDns {
   }
 
   _requestOptions(opts) {
+    let parsedUrl = url.parse(opts.url);
+
     return {
-      service: 'vinyldns',
-      region: 'us-east-1',
-      host: url.parse(opts.url).host,
-      url: opts.url,
-      method: opts.method || 'get',
+      host: parsedUrl.host,
+      uri: opts.url,
+      method: opts.method ? opts.method.toUpperCase() : 'GET',
+      path: parsedUrl.path,
       headers: {
         'Content-Type': 'application/json'
       },


### PR DESCRIPTION
Fixes issue #1

It appears that VinylDNS requires a `path` and an all-uppercase `method`
name be passed to the `aws4` signing library.

Without these 2 changes to the data passed to `aws4.sign`,
VinylDNS returns:

```
401: Authentication Failed: Request signature could not be validated
```

It also seems `service` and `region` are not required.