### PR TITLE
Improved integration tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,8 @@ module.exports = {
   },
  "globals": {
     "it": true,
-    "describe": true
+    "describe": true,
+    "before": true
   },
   "extends": "eslint:recommended",
   "rules": {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,6 @@ module.exports = {
     "semi": [
       "error",
       "always"
-    ],
-    "no-console": "off"
+    ]
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     "semi": [
       "error",
       "always"
-    ]
+    ],
+    "no-console": "off"
   }
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: node_js
 
 script: npm test && npm run integration-tests
 
+after_script: .vinyldns/bin/remove-vinyl-containers.sh
+
 node_js:
 - 10.15.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,8 @@ after_script: .vinyldns/bin/remove-vinyl-containers.sh
 
 node_js:
 - 10.15.0
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change

--- a/bin/run-integration-tests.sh
+++ b/bin/run-integration-tests.sh
@@ -21,6 +21,6 @@ echo "Starting localhost:9000 VinylDNS API instance..."
 
 echo "Executing vinyldns-js integration tests..."
 
-node_modules/.bin/mocha test/integration/*.js
+node_modules/.bin/mocha --timeout 3000 test/integration/*.js
 
 .vinyldns/bin/remove-vinyl-containers.sh

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "node_modules/.bin/mocha && ./node_modules/.bin/eslint src/*.js test/**/*.js",
     "integration-tests": "bin/run-integration-tests.sh",
+    "start-api": ".vinyldns/bin/docker-up-vinyldns.sh --api-only --version 0.8.0",
     "stop-api": ".vinyldns/bin/remove-vinyl-containers.sh",
     "repl": "node bin/repl.js"
   },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "node_modules/.bin/mocha && ./node_modules/.bin/eslint src/*.js test/**/*.js",
     "integration-tests": "bin/run-integration-tests.sh",
+    "stop-api": ".vinyldns/bin/remove-vinyl-containers.sh",
     "repl": "node bin/repl.js"
   },
   "repository": {

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -23,7 +23,7 @@ const vinyl = new VinylDNS({
   secretAccessKey: 'okSecretKey'
 });
 
-const group = function(name) {
+const buildGroup = function(name) {
   return {
     name: name || 'ok-group',
     description: 'description',
@@ -39,7 +39,7 @@ const group = function(name) {
   };
 };
 
-const zone = function(groupId, name) {
+const buildZone = function(groupId, name) {
   return {
     adminGroupId: groupId,
     name: name || 'vinyldns.',
@@ -53,12 +53,12 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
 
   describe('its support of VinylDNS group creation', () => {
     it('can create groups', (done) => {
-      vinyl.createGroup(group())
+      vinyl.createGroup(buildGroup())
         .then(result => {
           // save the result in the `testGroup` variable for other tests to use
           testGroup = result;
 
-          assert.equal(result.group.name, 'ok-group');
+          assert.equal(result.name, 'ok-group');
 
           done();
         });
@@ -107,7 +107,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
 
   describe('its support of VinylDNS zone creation', () => {
     it('can create a zone', (done) => {
-      vinyl.createZone(zone(testGroup.id))
+      vinyl.createZone(buildZone(testGroup.id))
         .then(result => {
           // Save the result as `testZone` for other tests to use
           testZone = result;
@@ -189,10 +189,10 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
   });
 
   describe('its support of deleting VinylDNS groups', () => {
-    it('can delete a group', (done) => {
+    it('will report an error if it attempts to delete an admin group', (done) => {
       vinyl.deleteGroup(testGroup.id)
-        .then(result => {
-          assert.equal(result.status, 'Deleted');
+        .catch(err => {
+          assert.equal(err.message, '400: "group-tests-group-updated is the admin of a zone. Cannot delete."');
 
           done();
         });

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -91,12 +91,34 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
         });
     });
 
-    it('can fetch group activity', (done) => {
-      vinyl.getGroupActivity(testGroup.id)
+    it('can update a group', (done) => {
+      vinyl.getGroups()
         .then(result => {
-          assert.equal(result.changes[0].newGroup.name, 'group-tests-group');
+          let g = result.groups.find(group => group.name === 'group-tests-group');
 
-          done();
+          g.name = 'group-tests-group-updated';
+
+          vinyl.updateGroup(g)
+            .then(result => {
+
+              assert.equal(result.name, 'group-tests-group-updated');
+
+              done();
+            });
+        });
+    });
+
+    it('can fetch group activity', (done) => {
+      vinyl.getGroups()
+        .then(result => {
+          let g = result.groups.find(group => group.name.includes('group-tests-group'));
+
+          vinyl.getGroupActivity(g.id)
+            .then(result => {
+              assert.equal(result.changes[0].newGroup.name.includes('group-tests-group'), true);
+
+              done();
+            });
         });
     });
 

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -52,7 +52,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
   let testZone;
 
   before(() => {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       vinyl.createGroup(group())
         .then(result => {
           testGroup = result;
@@ -65,6 +65,9 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
               setTimeout(() => {
                 resolve();
               }, 1600);
+            })
+            .catch(err => {
+              reject(err);
             });
         });
     });

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -153,7 +153,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
 
     it('can delete a zone', (done) => {
       // setTimeout ensures we wait until the zone is properly created
-      setTimout(() => {
+      setTimeout(() => {
         vinyl.getZones()
           .then(result => {
             vinyl.deleteZone(result.zones.find(z => z.name === 'zones-tests-zone.').id)
@@ -162,7 +162,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
 
                 done();
               });
-          });
+            });
        }, 2000);
     });
   });

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -123,7 +123,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
     });
 
     it('can fetch group members', (done) => {
-      vinyl.getGroupAdmins(testGroup.id)
+      vinyl.getGroupMembers(testGroup.id)
         .then(result => {
           assert.equal(result.members[0].userName, 'ok');
 
@@ -131,7 +131,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
         });
     });
 
-    it('can fetch group admins (when there are groups)', (done) => {
+    it('can fetch group members', (done) => {
       vinyl.getGroupAdmins(testGroup.id)
         .then(result => {
           assert.equal(result.admins[0].userName, 'ok');
@@ -143,7 +143,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
     it('can delete a group', (done) => {
       vinyl.getGroups()
         .then(groups => {
-          vinyl.deleteGroup(groups.groups.find(g => g.name === 'group-tests-group').id)
+          vinyl.deleteGroup(groups.groups.find(g => g.name.includes('group-tests-group')).id)
             .then(result => {
               assert.equal(result.status, 'Deleted');
 

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -91,39 +91,30 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
         });
     });
 
-    it('can fetch group activity (when there are groups)', (done) => {
-      vinyl.getGroups()
+    it('can fetch group activity', (done) => {
+      vinyl.getGroupActivity(testGroup.id)
         .then(result => {
-          vinyl.getGroupActivity(result.groups[0].id)
-            .then(result => {
-              assert.equal(result.changes[0].newGroup.name, 'group-tests-group');
+          assert.equal(result.changes[0].newGroup.name, 'group-tests-group');
 
-              done();
-            });
+          done();
         });
     });
 
-    it('can fetch group members (when there are groups)', (done) => {
-      vinyl.getGroups()
+    it('can fetch group members', (done) => {
+      vinyl.getGroupAdmins(testGroup.id)
         .then(result => {
-          vinyl.getGroupAdmins(result.groups.find(g => g.name === 'group-tests-group').id)
-            .then(result => {
-              assert.equal(result.members[0].userName, 'ok');
+          assert.equal(result.members[0].userName, 'ok');
 
-              done();
-            });
+          done();
         });
     });
 
     it('can fetch group admins (when there are groups)', (done) => {
-      vinyl.getGroups()
+      vinyl.getGroupAdmins(testGroup.id)
         .then(result => {
-          vinyl.getGroupAdmins(result.groups.find(g => g.name === 'group-tests-group').id)
-            .then(result => {
-              assert.equal(result.admins[0].userName, 'ok');
+          assert.equal(result.admins[0].userName, 'ok');
 
-              done();
-            });
+          done();
         });
     });
 
@@ -161,15 +152,18 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
     });
 
     it('can delete a zone', (done) => {
-      vinyl.getZones()
-        .then(result => {
-          vinyl.deleteZone(result.zones.find(z => z.name === 'zones-tests-zone').id)
-            .then(result => {
-              assert.equal(result.zone.status, 'Deleted');
+      // setTimeout ensures we wait until the zone is properly created
+      setTimout(() => {
+        vinyl.getZones()
+          .then(result => {
+            vinyl.deleteZone(result.zones.find(z => z.name === 'zones-tests-zone.').id)
+              .then(result => {
+                assert.equal(result.zone.status, 'Deleted');
 
-              done();
-            });
-        });
+                done();
+              });
+          });
+       }, 2000);
     });
   });
 

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -110,7 +110,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
       vinyl.createZone(buildZone(testGroup.id))
         .then(result => {
           // Save the result as `testZone` for other tests to use
-          testZone = result.zone;
+          testZone = result;
 
           // Pause to allow the zone to propagate before proceeding to other tests, where the zone is used
           setTimeout(() => {
@@ -126,7 +126,6 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
     it('can fetch all zones', (done) => {
       vinyl.getZones()
         .then(result => {
-          console.log('RESULT: ', result);
           assert.equal(result.zones[0].name, testZone.zone.name);
 
           done();
@@ -134,8 +133,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
     });
 
     it('can fetch individual zones', (done) => {
-      console.log(testZone);
-      vinyl.getZone(testZone.id)
+      vinyl.getZone(testZone.zone.id)
         .then(result => {
           assert.equal(result.zone.name, testZone.zone.name);
 
@@ -203,7 +201,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
 
   describe('its support of VinylDNS zone deletion', () => {
     it('can delete a zone', (done) => {
-      vinyl.deleteZone(testZone.id)
+      vinyl.deleteZone(testZone.zone.id)
         .then(result => {
           assert.equal(result.zone.status, 'Deleted');
 

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -60,6 +60,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
           vinyl.createZone(zone(result.id))
             .then(result => {
               testZone = result;
+              resolve(result);
             })
             .catch(err => {
               reject(err);

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -110,7 +110,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
       vinyl.createZone(buildZone(testGroup.id))
         .then(result => {
           // Save the result as `testZone` for other tests to use
-          testZone = result;
+          testZone = result.zone;
 
           // Pause to allow the zone to propagate before proceeding to other tests, where the zone is used
           setTimeout(() => {
@@ -126,6 +126,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
     it('can fetch all zones', (done) => {
       vinyl.getZones()
         .then(result => {
+          console.log('RESULT: ', result);
           assert.equal(result.zones[0].name, testZone.zone.name);
 
           done();
@@ -133,6 +134,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
     });
 
     it('can fetch individual zones', (done) => {
+      console.log(testZone);
       vinyl.getZone(testZone.id)
         .then(result => {
           assert.equal(result.zone.name, testZone.zone.name);

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -162,8 +162,8 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
 
                 done();
               });
-            });
-       }, 2000);
+          });
+      }, 2000);
     });
   });
 

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -171,4 +171,39 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
         });
     });
   });
+
+  describe('its support of VinylDNS record sets', () => {
+    let testZone;
+
+    before(() => {
+      return new Promise(resolve => {
+        vinyl.createGroup(group)
+          .then(result => {
+            vinyl.createZone(zone(result.id))
+              .then(result => {
+                testZone = result;
+
+                resolve();
+              });
+          });
+      });
+    });
+
+    it('can create a record set', (done) => {
+      vinyl.createRecordSet({
+        name: 'foo',
+        type: 'A',
+        ttl: 300,
+        records: [{
+          address: '10.10.10.10'
+        }],
+        zoneId: testZone.zone.id
+      })
+        .then(result => {
+          assert.equal(result.recordSet.name, 'foo');
+
+          done();
+        });
+    });
+  });
 });

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -196,7 +196,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
 
     it('can create a record set', (done) => {
       vinyl.createRecordSet({
-        name: 'foo',
+        name: 'record-set-tests-create',
         type: 'A',
         ttl: 300,
         records: [{
@@ -205,7 +205,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
         zoneId: testZone.zone.id
       })
         .then(result => {
-          assert.equal(result.recordSet.name, 'foo');
+          assert.equal(result.recordSet.name, 'record-set-tests-create');
 
           done();
         });

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -64,6 +64,9 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
             .catch(err => {
               reject(err);
             });
+        })
+        .catch(err => {
+          reject(err);
         });
     });
   });

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -185,7 +185,10 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
               .then(result => {
                 testZone = result;
 
-                resolve();
+                // wait until the zone has been created.
+                setTimeout(() => {
+                  resolve();
+                }, 1600);
               });
           });
       });

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -60,11 +60,6 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
           vinyl.createZone(zone(result.id))
             .then(result => {
               testZone = result;
-
-              // wait until the zone has been created.
-              setTimeout(() => {
-                resolve();
-              }, 1600);
             })
             .catch(err => {
               reject(err);

--- a/test/integration/vinyldns_test.js
+++ b/test/integration/vinyldns_test.js
@@ -23,18 +23,20 @@ const vinyl = new VinylDNS({
   secretAccessKey: 'okSecretKey'
 });
 
-const group = {
-  name: 'ok-group',
-  description: 'description',
-  email: 'test@test.com',
-  members: [{
-    userName: 'ok',
-    id: 'ok'
-  }],
-  admins: [{
-    userName: 'ok',
-    id: 'ok'
-  }]
+const group = function(name) {
+  return {
+    name: name || 'ok-group',
+    description: 'description',
+    email: 'test@test.com',
+    members: [{
+      userName: 'ok',
+      id: 'ok'
+    }],
+    admins: [{
+      userName: 'ok',
+      id: 'ok'
+    }]
+  };
 };
 
 const zone = function(groupId) {
@@ -57,9 +59,9 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
     });
 
     it('can create a group', (done) => {
-      vinyl.createGroup(group)
+      vinyl.createGroup(group('group-tests-group'))
         .then(result => {
-          assert.equal(result.name, 'ok-group');
+          assert.equal(result.name, 'group-tests-group');
 
           done();
         });
@@ -68,7 +70,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
     it('can fetch all groups (when there are groups)', (done) => {
       vinyl.getGroups()
         .then(result => {
-          assert.equal(result.groups[0].name, 'ok-group');
+          assert.equal(result.groups[0].name, 'group-tests-group');
 
           done();
         });
@@ -79,7 +81,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
         .then(result => {
           vinyl.getGroupActivity(result.groups[0].id)
             .then(result => {
-              assert.equal(result.changes[0].newGroup.name, 'ok-group');
+              assert.equal(result.changes[0].newGroup.name, 'group-tests-group');
 
               done();
             });
@@ -113,7 +115,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
     it('can delete a group', (done) => {
       vinyl.getGroups()
         .then(groups => {
-          vinyl.deleteGroup(groups.groups[0].id)
+          vinyl.deleteGroup(groups.groups.find(g => g.name === 'group-tests-group').id)
             .then(result => {
               assert.equal(result.status, 'Deleted');
 
@@ -134,7 +136,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
     });
 
     it('can create a zone', (done) => {
-      vinyl.createGroup(group)
+      vinyl.createGroup(group('zone-tests-group'))
         .then(result => {
           vinyl.createZone(zone(result.id))
             .then(result => {
@@ -177,7 +179,7 @@ describe('VinylDNS interaction with a real VinylDNS API', () => {
 
     before(() => {
       return new Promise(resolve => {
-        vinyl.createGroup(group)
+        vinyl.createGroup(group('record-set-tests-group'))
           .then(result => {
             vinyl.createZone(zone(result.id))
               .then(result => {


### PR DESCRIPTION
This PR adds additional integration tests, as well as improves the technique employed in executing the existing integration tests.

While there are still test cases missing from the integration tests, this PR still offers some improvements and additional test coverage.

While the unit tests run against mocked endpoints can be run via `npm test`, he integration tests can be run via `npm run integration-tests`.