### PR TITLE
ci: update release workflow node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Setup .npmrc file
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 25
           registry-url: https://registry.npmjs.org/
 
       - run: npm ci


### PR DESCRIPTION
## Summary
- update the release workflow to use `actions/setup-node@v4`
- move the release job from Node 14 to Node 25 to match `verify`
- fix `npm ci` for the current `lockfileVersion: 3` lockfile during npm publish

## Problem
The `release` workflow still used Node 14 via `actions/setup-node@v2`, while `verify` already used Node 25 via `actions/setup-node@v4`.

That meant the release job ran an older npm against the current lockfile. Reproduced locally:
- `npx -p npm@6 npm ci` fails with `Cannot read properties of undefined (reading 'aws4')`
- modern `npm ci` succeeds against the same committed lockfile

## Testing
- verified the workflow diff only updates the release job node setup
- reproduced the failure with npm 6 locally
- verified `npm ci` succeeds with modern npm locally
